### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description = library for Postmark


### PR DESCRIPTION
Dash-separated keys such as  'description-file' are no longer supported by setuptools